### PR TITLE
perf: add caching for fetched etching

### DIFF
--- a/src/indexer/updater.ts
+++ b/src/indexer/updater.ts
@@ -290,6 +290,10 @@ export class RuneUpdater implements RuneBlockIndex {
           throw new Error('Rune should exist at this point');
         }
 
+        if (!etchingByRuneId.has(runeIdString)) {
+          etchingByRuneId.set(runeIdString, etching);
+        }
+
         this.utxoBalances.push({
           runeId: balance.runeId,
           runeTicker: etching.runeTicker,


### PR DESCRIPTION
In my logs, I have seen the same fetch on many iterations that could benefit from this micro optimization. After it's fetched once, it can be stored in the local dictionary and used in subsequent iterations. This will significantly reduce subsequent DB calls after the first one is cached. 